### PR TITLE
add support for TS-XW initialization

### DIFF
--- a/tminit.c
+++ b/tminit.c
@@ -72,11 +72,12 @@ static const struct tm_wheel_info tm_wheels_infos[] = {
 	{0x02, 0x06, 0x0005, "Thrustmaster T300RS"},
 	{0x02, 0x09, 0x0005, "Thrustmaster T300RS (Open Wheel Attachment)"},
 	{0x03, 0x06, 0x0006, "Thrustmaster T150RS"},
-	{0x00, 0x09, 0x000b, "Thrustmaster T128"}
+	{0x00, 0x09, 0x000b, "Thrustmaster T128"},
+	{0x07, 0x0a, 0x000a, "Thrustmaster TS-XW"}
 	//{0x04, 0x07, 0x0001, "Thrustmaster TMX"}
 };
 
-static const uint8_t tm_wheels_infos_length = 8;
+static const uint8_t tm_wheels_infos_length = 9;
 
 
 /* The control packet to send to wheel */
@@ -214,7 +215,7 @@ static void thrustmaster_model_handler(struct urb *urb)
 				tm_wheel->response->type);
 		return;
 	}
-
+	
 	for (i = 0; i < tm_wheels_infos_length && !twi; i++)
 		if (tm_wheels_infos[i].model == model)
 			twi = tm_wheels_infos + i;

--- a/tminit.c
+++ b/tminit.c
@@ -215,7 +215,7 @@ static void thrustmaster_model_handler(struct urb *urb)
 				tm_wheel->response->type);
 		return;
 	}
-	
+
 	for (i = 0; i < tm_wheels_infos_length && !twi; i++)
 		if (tm_wheels_infos[i].model == model)
 			twi = tm_wheels_infos + i;

--- a/usb-tminit.c
+++ b/usb-tminit.c
@@ -31,6 +31,7 @@ static void thrustmaster_usb_disconnect(struct usb_interface *interface)
 
 static const struct usb_device_id thrustmaster_usb_devices[] = {
 	{ USB_DEVICE(0x044f, 0xb69c) },
+	{ USB_DEVICE(0x044f, 0xb691) },
 	{}
 };
 


### PR DESCRIPTION
Output:

```
yassine@archlinux ~/hid-tmff2 (master)> sudo dmesg -W
[255365.548460] usb 3-1: new full-speed USB device number 6 using xhci_hcd
[255365.714021] usb 3-1: New USB device found, idVendor=044f, idProduct=b691, bcdDevice= 1.01
[255365.714026] usb 3-1: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[255365.714028] usb 3-1: Product: Thrustmaster TS-XW Racer GIP Wheel
[255365.714030] usb 3-1: Manufacturer: Thrustmaster
[255365.714032] usb 3-1: SerialNumber: 0000XXXXXXXXXXXX
[255370.805385] usb-thrustmaster 3-1:1.0: setup data couldn't be sent
[255370.807026] usb-thrustmaster 3-1:1.0: Wheel with (model, attachment) = (0x7, 0xa) is a Thrustmaster TS-XW. attachment_found=1
[255370.808122] usb 3-1: USB disconnect, device number 6
[255370.808216] usb-thrustmaster 3-1:1.0: URB to change wheel mode seems to have failed, error code -2
[255371.431808] usb 3-1: new full-speed USB device number 7 using xhci_hcd
[255371.597627] usb 3-1: New USB device found, idVendor=044f, idProduct=b692, bcdDevice= 1.00
[255371.597631] usb 3-1: New USB device strings: Mfr=1, Product=2, SerialNumber=0
[255371.597633] usb 3-1: Product: Thrustmaster TS-XW Racer
[255371.597634] usb 3-1: Manufacturer: Thrustmaster
[255371.616734] input: Thrustmaster Thrustmaster TS-XW Racer as /devices/pci0000:00/0000:00:08.1/0000:10:00.3/usb3/3-1/3-1:1.0/0003:044F:B692.0008/input/input31
[255371.616808] tmff2 0003:044F:B692.0008: input,hidraw7: USB HID v1.11 Joystick [Thrustmaster Thrustmaster TS-XW Racer] on usb-0000:10:00.3-1/input0
[255371.643668] tmff2 0003:044F:B692.0008: force feedback for TS-XW
```

